### PR TITLE
Revert "MySQLクエリーキャッシュを有効化"

### DIFF
--- a/development/mysql/custom.conf
+++ b/development/mysql/custom.conf
@@ -7,9 +7,6 @@ max_connections=10000
 slow_query_log
 slow_query_log-file = /var/log/mysql/mysql-slow.sql
 long_query_time = 0.2
-# クエリーキャッシュ https://weblabo.oscasierra.net/mysql-query-cache/
-query_cache_type=1
-query_alloc_block_size=32M
 [client]
 loose-local-infile=1
 default-character-set=utf8mb4


### PR DESCRIPTION
Reverts shwatanap/42HoursTuningTheBackend#14

MySQL8 からはクエリーキャッシュオプションが無いらしい。